### PR TITLE
P6 cl 158 fix bug of vite env vars not recognized correctly by ts

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,13 +22,12 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
+    /* Vite Support */
+    "types": ["vite/client"],
+
     /* Shad UI install */
     "baseUrl": ".",
-    "paths": {
-      "@/*": [
-        "./src/*"
-      ]
-    }
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This PR fixes the bug of typescript does not recognizes the vite env variables correctly when run `npm run build`.
✅added `"types": ["vite/client"]"` to `tsconfig.app.json`

Before:
![image](https://github.com/user-attachments/assets/db9df8b8-f1c8-441a-a27a-525b46840d32)
After:
import.meta.env realted bugs disappear
