### PR TITLE
P6 cl154 reform when db functions called 

### DIFF
--- a/src/components/AppSidebar/AppSidebar.tsx
+++ b/src/components/AppSidebar/AppSidebar.tsx
@@ -7,11 +7,8 @@ import {
   SidebarMenuItem,
 } from '@/components/ui/sidebar'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useState } from 'react'
 import { AvatarImage } from '@radix-ui/react-avatar'
-import { getUserById } from '../../../firebase/functions/getUserById'
-import { getGoalBuddyByUserId } from '../../../firebase/functions/getGoalBuddyByUserId'
-import { GoalBuddy, User } from '@/types/types'
 import './AppSidebar.css'
 import UserProfileModal from '../Modal/UserProfileModal'
 import { IdContext } from '../context/IdContext'
@@ -25,35 +22,19 @@ const items = [
 ]
 
 export function AppSidebar() {
-  const [userData, setUserData] = useState<User | null>(null)
-  const [goalBuddyData, setGoalBuddyData] = useState<GoalBuddy | null>(
-    null,
-  )
   const [modalOpen, setModalOpen] = useState(false)
 
-  const context = useContext(IdContext)
-  const userId = context?.userId
+  const userContext = useContext(IdContext)
+  if (!userContext) {
+    throw new Error('IdContext not found')
+  }
+  const { userData, goalBuddyData, setGoalBuddyData } = userContext
+
   const sidebarContext = useContext(SidebarContext)
   if (!sidebarContext) {
     throw new Error('Sidebar context not found')
   }
   const { isSidebarOpen, setIsSideBarOpen } = sidebarContext
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const [userResponse, goalBuddyResponse] = await Promise.all([
-          getUserById(userId as string),
-          getGoalBuddyByUserId(userId as string),
-        ])
-        setUserData(userResponse)
-        setGoalBuddyData(goalBuddyResponse)
-      } catch (error) {
-        console.error('Failed to fetch data', error)
-      }
-    }
-    fetchData()
-  }, [userId])
 
   const handleClick = (title: string) => {
     if (title === 'Profile') setModalOpen(!modalOpen)
@@ -119,7 +100,6 @@ export function AppSidebar() {
         <UserProfileModal
           setModalOpen={setModalOpen}
           modalOpen={modalOpen}
-          userId={userId || ''}
           goalBuddyData={goalBuddyData}
           updateGoalBuddyData={setGoalBuddyData}
         />

--- a/src/components/Modal/GoalBuddyProfileModal.tsx
+++ b/src/components/Modal/GoalBuddyProfileModal.tsx
@@ -17,12 +17,12 @@ const GoalBuddyProfileModal: React.FC<ModalProps> = ({
   goalBuddy,
 }) => {
 
-  const context: IdType | undefined = useContext(IdContext)
-  let activeUserId: string = "";
-
-  if(context){
-    activeUserId = context.userId;
+  const userContext: IdType | undefined = useContext(IdContext)
+  if (!userContext) {
+    throw new Error('IdContext not found')
   }
+  const { userData } = userContext
+  
   
   return (
     <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
@@ -35,8 +35,8 @@ const GoalBuddyProfileModal: React.FC<ModalProps> = ({
           <GoalBuddyProfile goalBuddy={goalBuddy} />
         </div>
         <div className="flex flex-col items-center h-full w-[45%] bg-[#279af1] p-0 overflow-hidden rounded">
-          {context ? (
-            <MeetingSetupSection activeUserId={activeUserId} showingUser={goalBuddy} />
+          {userContext && userData ? (
+            <MeetingSetupSection activeUserId={userData.id} showingUser={goalBuddy} />
           ) : (
             <p>{`Context for the Active User not found.`}</p>
           )}

--- a/src/components/Modal/UserProfileModal.tsx
+++ b/src/components/Modal/UserProfileModal.tsx
@@ -8,19 +8,18 @@ import { GoalBuddy } from '../../types/types'
 interface ModalProps {
   setModalOpen: React.Dispatch<React.SetStateAction<boolean>>
   modalOpen: boolean
-  userId: string
   goalBuddyData: GoalBuddy | null
   updateGoalBuddyData: (data: GoalBuddy) => void
   
 }
 
-const UserprofileModal: React.FC<ModalProps> = ({ setModalOpen, modalOpen, userId, goalBuddyData, updateGoalBuddyData }) => {
+const UserprofileModal: React.FC<ModalProps> = ({ setModalOpen, modalOpen, goalBuddyData, updateGoalBuddyData }) => {
   return (
     <Dialog  open={modalOpen} onOpenChange={setModalOpen} >
       <DialogContent className="flex max-w-[50vw] flex-row bg-[#EEEEEE] h-[70%] p-0 gap-0 rounded"  aria-describedby={undefined}>
         <DialogTitle></DialogTitle>
         <div className="flex flex-col w-[55%] pt-0 pl-0 overflow-y-auto scrollbar-hidden">
-          <UserProfile userId={userId} />
+          <UserProfile />
         </div>
         <div className="flex flex-col items-center w-[45%] bg-[#23A8E7] p-0  overflow-hidden rounded">
             {goalBuddyData ? (

--- a/src/components/context/IdContext.tsx
+++ b/src/components/context/IdContext.tsx
@@ -1,16 +1,44 @@
-import { IdType } from "@/types/types";
-import { createContext } from "react";
+import { GoalBuddy, IdType, User } from '@/types/types'
+import { getGoalBuddyByUserId } from '../../../firebase/functions/getGoalBuddyByUserId'
+import { getUserById } from '../../../firebase/functions/getUserById'
+import { createContext, useEffect, useState } from 'react'
 
+export const IdContext = createContext<IdType | undefined>(undefined)
+import { ReactNode } from 'react'
 
-export const IdContext=createContext<IdType|undefined>(undefined)
-import { ReactNode } from "react";
+export const IdProvider = ({ children }: { children: ReactNode }) => {
+	const [userData, setUserData] = useState<User | null>(null)
+	const [goalBuddyData, setGoalBuddyData] = useState<GoalBuddy | null>(null)
+	
+	const userId = 'oPpkEtk18BefnQNijnUU'
 
-export const IdProvider=({children}: {children: ReactNode})=>{
-    const userId="pSuTJe464b8q86l6whPM";
-    const goalBuddyId="yfKMqgkDsrPxWc1jUoU9";
-    return(
-        <IdContext.Provider value={{userId,goalBuddyId}}>
-            {children}
-        </IdContext.Provider>
-    )
+	console.log(userData);
+	console.log(goalBuddyData);
+	
+
+  useEffect(() => {
+		console.log('called');
+		
+    const fetchUserData = async () => {
+      try {
+        const [userResponse, goalBuddyResponse] = await Promise.all([
+          getUserById(userId),
+          getGoalBuddyByUserId(userId),
+        ])
+        setUserData(userResponse)
+        setGoalBuddyData(goalBuddyResponse)
+      } catch (error) {
+        console.error('Failed to fetch data', error)
+      }
+    }
+    fetchUserData()
+  }, [userId])
+
+  return (
+    <IdContext.Provider
+      value={{ userData, setUserData, goalBuddyData, setGoalBuddyData }}
+    >
+      {children}
+    </IdContext.Provider>
+  )
 }

--- a/src/components/context/IdContext.tsx
+++ b/src/components/context/IdContext.tsx
@@ -12,13 +12,7 @@ export const IdProvider = ({ children }: { children: ReactNode }) => {
 	
 	const userId = 'oPpkEtk18BefnQNijnUU'
 
-	console.log(userData);
-	console.log(goalBuddyData);
-	
-
   useEffect(() => {
-		console.log('called');
-		
     const fetchUserData = async () => {
       try {
         const [userResponse, goalBuddyResponse] = await Promise.all([

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -109,7 +109,9 @@ export interface AvailabilityErrors {
   endTimeError: string;
   errorsExist: boolean;
 }
-export interface IdType{
-    userId:string,
-    goalBuddyId:string
+export interface IdType {
+  userData: User | null
+  setUserData: (userData: User | null) => void
+  goalBuddyData: GoalBuddy | null
+  setGoalBuddyData: (goalBuddyData: GoalBuddy | null) => void
 }


### PR DESCRIPTION
Refactored for when db function is called to fetch data regarding the active user and moved the related function call and states to the existing iDContext module.

✅Moved nav bar logic to fetch data regarding active user to iDContext
✅Created new goalBuddy document to be used as the active user specifically in iDContext (id: BRlli3oTIOCDiujVWfRb)
✅Moved nav bar logic to fetch data regarding active user to iDContext

To test, check the functionality of: 
1. viewing the profile in the navbar
2. edit the data of the user on both the left and right side

Note: Another reason I created a new goalBuddy document was that this would be the dedicated active user and the goalbuddies shown in Colabpage would be the original 10 that were setup from the DB. Ticket #181 was made so that the new goalbuddy document was to not be included when the  Colabpage  renders "all" goalbuddy users. Currently and before this ticket, Colabpage would show all users, including the active user that was hard coded in iDContext.