### PR TITLE
P6 cl 149/182 - Fix Meeting time Listings not filtering out on invitee's existant meetings

### DIFF
--- a/firebase/functions/calendarEventsbyUserId.ts
+++ b/firebase/functions/calendarEventsbyUserId.ts
@@ -40,7 +40,6 @@ export async function getUserEvents(
       getDocs(createdUserQuery),
     ])
     if (inviteeSnapshot.empty && createdSnapshot.empty) {
-      console.log("Both invitee and creator empty");
       return []
     }
 
@@ -48,8 +47,6 @@ export async function getUserEvents(
     let creatorEvents: CalendarEvents[] = []
 
     if (date) {
-      console.log(date);
-
       inviteeEvents = inviteeSnapshot.docs
         .filter((item) => item.data().eventStartTime >= date)
         .map((item) => ({ id: item.id, ...(item.data() as BaseEvents) }))
@@ -67,8 +64,6 @@ export async function getUserEvents(
     }
 
     const mergeArray: CalendarEvents[] = [...inviteeEvents, ...creatorEvents];
-    console.log("final output");
-    console.log(mergeArray);
     return mergeArray;
 
   } catch (error) {

--- a/firebase/functions/calendarEventsbyUserId.ts
+++ b/firebase/functions/calendarEventsbyUserId.ts
@@ -16,6 +16,11 @@ we should filter events to only include those that occur on or after the specifi
 Also modified to rethrow the error to caller in cases where getDocs return an error
 @author[Jeffrey]*/
 
+/*
+* @editor [Katrina]
+* Function previously returned an empty array if no date was provided, regardless of other data found. Fixed so that it now returns the merged list of invitee and creator events without applying the date filter.
+*/
+
 export async function getUserEvents(
   userId: string,
   date?: Timestamp,
@@ -35,22 +40,37 @@ export async function getUserEvents(
       getDocs(createdUserQuery),
     ])
     if (inviteeSnapshot.empty && createdSnapshot.empty) {
+      console.log("Both invitee and creator empty");
       return []
     }
-    let events1: CalendarEvents[] = []
-    let events2: CalendarEvents[] = []
+
+    let inviteeEvents: CalendarEvents[] = []
+    let creatorEvents: CalendarEvents[] = []
 
     if (date) {
-      events1 = inviteeSnapshot.docs
+      console.log(date);
+
+      inviteeEvents = inviteeSnapshot.docs
         .filter((item) => item.data().eventStartTime >= date)
         .map((item) => ({ id: item.id, ...(item.data() as BaseEvents) }))
-      events2 = createdSnapshot.docs
+      
+        creatorEvents = createdSnapshot.docs
         .filter((item) => item.data().eventStartTime >= date)
+        .map((item) => ({ id: item.id, ...(item.data() as BaseEvents) }))
+
+    }else{
+      inviteeEvents = inviteeSnapshot.docs
+        .map((item) => ({ id: item.id, ...(item.data() as BaseEvents) }))
+      
+        creatorEvents = createdSnapshot.docs
         .map((item) => ({ id: item.id, ...(item.data() as BaseEvents) }))
     }
 
-    const mergeArray = [...events1, ...events2]
-    return mergeArray
+    const mergeArray: CalendarEvents[] = [...inviteeEvents, ...creatorEvents];
+    console.log("final output");
+    console.log(mergeArray);
+    return mergeArray;
+
   } catch (error) {
     console.error('Error getting documents: ', error)
     throw error // Re-throw the error to handle it in the calling function

--- a/firebase/functions/createCalendarEvent.ts
+++ b/firebase/functions/createCalendarEvent.ts
@@ -7,12 +7,17 @@ import { EventData } from '@/types/types'
 /*modified to rethrow error to caller function
 @author[Jeffrey]*/
 
+/*
+* @editor[Katrina]
+* Fixed error that stored new events with an eventData field with sub-fields rather than making each data point stored in eventData its own field.
+*/
+
 export async function createCalendarEvent(
   eventData: EventData,
 ): Promise<object | null> {
   try {
     const eventDoc = {
-      eventData,
+      ...eventData,
       createdAt: Timestamp.now(),
       updatedAt: Timestamp.now(),
     }

--- a/firebase/schemas.ts
+++ b/firebase/schemas.ts
@@ -25,7 +25,7 @@ export const AvailabilitiesSchema = z.object({
       'Saturday',
       'Sunday',
   ]),
-  timePeriod: z.array(TimePeriodSchema)
+  timePeriods: z.array(TimePeriodSchema)
 })
 
 export const GoalBuddySchema = z.object({

--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -32,7 +32,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
         // Populate the inputs when the selected day changes to one with times
         } else {
             const currentTimePeriods: TimePeriodDisplay[] = [];      
-            selectedDayAvailability.timePeriod.forEach((period) => {
+            selectedDayAvailability.timePeriods.forEach((period) => {
                 const startString: string = formatTimeString(period.startTime);
                 const endString: string = formatTimeString(period.endTime);
                 currentTimePeriods.push({startTime: startString, endTime: endString})
@@ -129,7 +129,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
         timePeriodInputs.forEach((period) => {
             updatedTimePeriods.push({ startTime: createTimeFromStrings(period.startTime), endTime: createTimeFromStrings(period.endTime) });
         });
-        const createdAvailability: Availabilities = { day: selectedDay!, timePeriod: updatedTimePeriods };
+        const createdAvailability: Availabilities = { day: selectedDay!, timePeriods: updatedTimePeriods };
 
         // Copy the availability items to updatedAvailabilities
         let selectDayExists: boolean = false;

--- a/src/components/MeetingSetupSection/MeetingSetupSection.tsx
+++ b/src/components/MeetingSetupSection/MeetingSetupSection.tsx
@@ -134,11 +134,20 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
               availableTimes.push(meetingPeriod);
 
             }
-
             // Set the next start time to be 30 minutes later (aka the meetingEndTime)
             meetingStartTime = meetingEndTime;
           }
         }
+
+        // Sort the availableTimes array in chronological order
+        availableTimes.sort((a, b) => {
+          const aStartTime = new Date(selectedDate);
+          aStartTime.setHours(a.startTime.hours, a.startTime.minutes, 0, 0);
+          const bStartTime = new Date(selectedDate);
+          bStartTime.setHours(b.startTime.hours, b.startTime.minutes, 0, 0);
+          return aStartTime.getTime() - bStartTime.getTime();
+        });
+
         setAvailableTimes(availableTimes);
         setSelectedTime(undefined);
         setDate(selectedDate);

--- a/src/components/MeetingSetupSection/MeetingSetupSection.tsx
+++ b/src/components/MeetingSetupSection/MeetingSetupSection.tsx
@@ -34,7 +34,8 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
       try {
         const currentDate: Timestamp = Timestamp.now()
         const data = await getUserEvents(userId, currentDate);
-
+        console.log("grabbed meetings");
+        console.log(data);
         // If the user has no meetings, set the userMeetings state to an empty array
         if (data.length === 0) {
           setUserMeetings([]);
@@ -82,8 +83,9 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
       // If the user has no availability for the selected day, set the times state to an empty array as no times will be available
       if (
         dailyAvailability === undefined ||
-        dailyAvailability.timePeriod.length === 0
+        dailyAvailability.timePeriods.length === 0
       ) {
+
         setAvailableTimes([]);
         setSelectedTime(undefined);
         setDate(selectedDate);
@@ -91,7 +93,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
 
       // Otherwise, we will create a list of available times for the selected day
       } else {
-        const meetingTimes: TimePeriod[] = dailyAvailability.timePeriod;
+        const meetingTimes: TimePeriod[] = dailyAvailability.timePeriods;
 
         // Go throuh each of the user's availability time periods for this day and add each 30 minute interval to the availableTimes array
         for (let i:number  = 0; i < meetingTimes.length; i++) {

--- a/src/components/MeetingSetupSection/MeetingSetupSection.tsx
+++ b/src/components/MeetingSetupSection/MeetingSetupSection.tsx
@@ -34,8 +34,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
       try {
         const currentDate: Timestamp = Timestamp.now()
         const data = await getUserEvents(userId, currentDate);
-        console.log("grabbed meetings");
-        console.log(data);
+
         // If the user has no meetings, set the userMeetings state to an empty array
         if (data.length === 0) {
           setUserMeetings([]);
@@ -167,8 +166,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
 
       // Call the createCalendarEvent function to create the event in the collection
       try {
-        const response = await createCalendarEvent(eventData)
-        console.log(response);
+        await createCalendarEvent(eventData)
         setConfirmationState(true);
 
       } catch (error) {

--- a/src/components/MeetingSetupSection/MeetingSetupSection.tsx
+++ b/src/components/MeetingSetupSection/MeetingSetupSection.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import BookingCalendar from '../BookingCalendar/BookingCalendar'
 import TimeSelectionList from '../TimeSelectionList/TimeSelectionList'
 import { CalendarEvents, AllGoalBuddyData, Availabilities, TimePeriod, Time, EventData } from '@/types/types'
-import { getUserEvents } from '../../../firebase/functions/calendarEventsbyUserId'
+import { getUserEvents } from '../../../firebase/functions/calendarEventsByUserId'
 import { createCalendarEvent } from '../../../firebase/functions/createCalendarEvent'
 import { Timestamp } from 'firebase/firestore'
 import { dayAsString, findAvailabilityForDay, createTimestamp, isExistingStartTime, formatTimeString } from '../../utils/dateHelpers'
@@ -165,7 +165,8 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
 
       // Call the createCalendarEvent function to create the event in the collection
       try {
-        await createCalendarEvent(eventData)
+        const response = await createCalendarEvent(eventData)
+        console.log(response);
         setConfirmationState(true);
 
       } catch (error) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -15,7 +15,7 @@ export type DayOfWeek = "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Frida
 
 export type Availabilities = {
   day: DayOfWeek,
-  timePeriod: TimePeriod[]
+  timePeriods: TimePeriod[]
 }
 
 //import { Timestamp } from "firebase/firestore"

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -43,6 +43,7 @@ export function createTimestamp(date: Date, time: {hours: number, minutes: numbe
 // author: Katrina
 export function isExistingStartTime(timestamp: Timestamp, meetings: CalendarEvents[] | undefined): boolean {
     if (!meetings) return false;
+    console.log(`compare: ${timestamp} to ${meetings}`);
     return meetings.some((meeting) => meeting.eventStartTime.seconds === timestamp.seconds);
 }
 

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -43,7 +43,6 @@ export function createTimestamp(date: Date, time: {hours: number, minutes: numbe
 // author: Katrina
 export function isExistingStartTime(timestamp: Timestamp, meetings: CalendarEvents[] | undefined): boolean {
     if (!meetings) return false;
-    console.log(`compare: ${timestamp} to ${meetings}`);
     return meetings.some((meeting) => meeting.eventStartTime.seconds === timestamp.seconds);
 }
 


### PR DESCRIPTION
This Pull Request address both bug tickets as they were intertwined enough that both needed to be addressed at the same time.
-Jira ticket [149](https://makeitmvp.atlassian.net/browse/P6CL-149?atlOrigin=eyJpIjoiN2I0ZjU3OTlkODEwNDEzMmIzYWU5NWVkYmMzNzRlNmQiLCJwIjoiaiJ9)
-Jira ticket [182](https://makeitmvp.atlassian.net/browse/P6CL-182?atlOrigin=eyJpIjoiM2RmZWYzNGEyYTA0NGQ4NzllMThjNWRjNjg3MzE5MTciLCJwIjoiaiJ9https://makeitmvp.atlassian.net/browse/P6CL-182?atlOrigin=eyJpIjoiM2RmZWYzNGEyYTA0NGQ4NzllMThjNWRjNjg3MzE5MTciLCJwIjoiaiJ9)

The recent database resets changed the field where availabilities time periods were stored, which also complicated things and required refactoring of some types.
✅Edit getUserEvents() to not return empty if no date is provided.
✅Edit createCalendarEvent() to add the individual fields to the database rather than an eventData field with all other data in sub-fields. Added fields to database for calendarEvent documents created with the wrong schema.
✅Refactor Availabilities type to have field "timePeriods" rather than "timePeriod". Updated all references and schemas that used the previous field name. Database updated to ensure all goalBuddy documents have an availabilities field that match the correct schema.
✅Sort time listings to display in chronological order

How to test:
1.) npm run dev
2.) select a user (not christine as they are the active user)
3.) Create a meeting, making note of the date and time you chose.
4.) Start to book a second meeting to confirm that the time slot of the previous meeting is no longer a choice.
5.) Try clicking on different dates to ensure the previous error from 182 does not appear in console. (was caused from the database changes)
6.) Test setting the current user's availabilities in the Edit Profile section. (as had to be refactored from database changes)