### PR TITLE
P6 cl 183 add tooltip to the filter component ffx

### DIFF
--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -1,8 +1,10 @@
 import { Card, CardContent, CardDescription } from '../ui/card'
-import { cn } from "../lib/utils"
+import { cn } from '../lib/utils'
 import MentorBadge from './MentorBadge'
 import GoalBuddyBadge from './GoalBuddyBadge'
 import NetworkingBadge from './NetworkingBadge'
+import { roleItems } from '@/utils/data'
+import { TooltipWrapper } from '../Tooltip/TooltipWrapper'
 
 interface filterProps {
   filterGoalBuddies: Function
@@ -14,50 +16,83 @@ interface filterProps {
 }
 
 const Filter: React.FC<filterProps> = ({ filterGoalBuddies, filter }) => {
-    const renderCheckbox = (filtered: boolean, role: string) => {
-        return (
-            <span 
-                className={cn(`cursor-pointer h-5 w-5 rounded-sm border-2 border-black self-center ml-4 ${filtered
-                    ? "bg-black" : "bg-white"
-                }`)}
-                onClick={() => {filterGoalBuddies(role)}}
-            />
-        )
-    }
-
-    const renderBadge = (tag: string) => {
-        switch (tag)  {
-            case 'mentor': return <MentorBadge width="w-8" stroke="2" /> 
-            case 'accountability': return <GoalBuddyBadge width="w-8" stroke="2" /> 
-            case 'networking': return <NetworkingBadge width="w-8" stroke="2" />
-        }
-    }
-
-    const renderRole = (tag: string, roleName: string, roleToFilter: boolean) => {
-        return (
-            <div className="flex flex-row justify-between relative h-8">
-                <label className="rounded-lg border-2 border-r-4 border-b-4 border-black w-48 h-9 pl-2 
-                    text-xl leading-[30px] relative font[Montserrat] font-medium">
-                    {renderBadge(tag)} {roleName}
-                </label>
-                {renderCheckbox(roleToFilter, tag)}
-            </div>
-        )
-    }
-
+  const renderCheckbox = (filtered: boolean, role: string) => {
     return (
-        <Card className={cn("lg:w-68 h-16 lg:h-44 mt-4 ml-4 pb-0 border-none shadow-none")}>
-            <CardContent className={cn("flex flex-row justify-between lg:flex-col gap-4 p-0 md:pr-4 md:pl-4")}>
-                {renderRole('mentor', 'Mentor', filter.mentor)}
-                {renderRole('accountability', 'Goal Buddy', filter.accountability)}
-                {renderRole('networking', 'Networking', filter.networking)}
-                <CardDescription 
-                    className={cn("text-right text-gray-800 text-base font[Montserrat] font-medium m-0 -mt-3 cursor-pointer")}
-                    onClick={() => filterGoalBuddies('')}>Clear All
-                </CardDescription>
-            </CardContent>
-        </Card>
+      <span
+        className={cn(
+          `cursor-pointer h-5 w-5 rounded-sm border-2 border-black self-center ml-4 ${
+            filtered ? 'bg-black' : 'bg-white'
+          }`,
+        )}
+        onClick={() => {
+          filterGoalBuddies(role)
+        }}
+      />
     )
+  }
+
+  const renderBadge = (tag: string) => {
+    switch (tag) {
+      case 'mentor':
+        return <MentorBadge width="w-8" stroke="2" />
+      case 'accountability':
+        return <GoalBuddyBadge width="w-8" stroke="2" />
+      case 'networking':
+        return <NetworkingBadge width="w-8" stroke="2" />
+    }
+  }
+
+  const getRoleItem = (role: string): Record<string, string> => {
+    return (
+      roleItems.find((item) => item.role === role) || {
+        icon: '',
+        role: 'Unknown',
+        description: 'Role not found',
+      }
+    )
+  }
+
+  const renderRole = (tag: string, roleName: string, roleToFilter: boolean) => {
+    return (
+      <div className="flex flex-row justify-between relative h-8">
+        <TooltipWrapper roleItem={getRoleItem(roleName)}>
+          <label
+            className="rounded-lg border-2 border-r-4 border-b-4 border-black w-48 h-9 pl-2 
+                    text-xl leading-[30px] relative font[Montserrat] font-medium"
+          >
+            {renderBadge(tag)} {roleName}
+          </label>
+        </TooltipWrapper>
+        {renderCheckbox(roleToFilter, tag)}
+      </div>
+    )
+  }
+
+  return (
+    <Card
+      className={cn(
+        'lg:w-68 h-16 lg:h-44 mt-4 ml-4 pb-0 border-none shadow-none',
+      )}
+    >
+      <CardContent
+        className={cn(
+          'flex flex-row justify-between lg:flex-col gap-4 p-0 md:pr-4 md:pl-4',
+        )}
+      >
+        {renderRole('mentor', 'Mentor', filter.mentor)}
+        {renderRole('accountability', 'Goal Buddy', filter.accountability)}
+        {renderRole('networking', 'Networking', filter.networking)}
+        <CardDescription
+          className={cn(
+            'text-right text-gray-800 text-base font[Montserrat] font-medium m-0 -mt-3 cursor-pointer',
+          )}
+          onClick={() => filterGoalBuddies('')}
+        >
+          Clear All
+        </CardDescription>
+      </CardContent>
+    </Card>
+  )
 }
 
 export default Filter

--- a/src/components/Tooltip/TooltipWrapper.tsx
+++ b/src/components/Tooltip/TooltipWrapper.tsx
@@ -15,7 +15,7 @@ export function TooltipWrapper({ roleItem, children }: TooltipWrapperProps) {
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipContent className="flex flex-col items-center p-4 gap-2 w-[390px] h-[120] text-black rounded-md border-t border-t-black border-r-2 border-r-black border-b-2 border-b-black border-l border-l-black bg-white absolute left-36 top-1/2 transform -translate-y-1/2">
+        <TooltipContent className="flex flex-col items-center p-4 gap-2 w-[390px] h-[120] text-black rounded-md border-t border-t-black border-r-2 border-r-black border-b-2 border-b-black border-l border-l-black bg-white absolute left-24 top-1/2 transform -translate-y-1/2">
           <img className="w-[30px]" src={roleItem.icon} alt="mentor-icon" />
           <p className="font-semibold text-[20px]">{roleItem.role}</p>
           <p className="text-center text-[16px]">{roleItem.description}</p>


### PR DESCRIPTION
This PR adds the tooltip component to the filter component, the changes include:
✅ wrap the role tag component with `TooltipWrapper` component
✅ edit `TooltipWrapper` component's styles

How to test:
hover over to the filter role tag, the tooltip should show up like the following pics:
![Screenshot 2025-02-24 at 6 31 48 PM](https://github.com/user-attachments/assets/ed00010f-a9d0-4cef-aecb-5008b3845d20)
![Screenshot 2025-02-24 at 6 31 24 PM](https://github.com/user-attachments/assets/dc2ab2e0-dd18-49d1-8444-2b09aa705cad)
![Screenshot 2025-02-24 at 6 30 35 PM](https://github.com/user-attachments/assets/62fb965d-4953-42b0-91d9-d70586a441cc)
