### PR TITLE
P6 cl205 fix small gb card styling 

### DIFF
--- a/src/components/GoalBuddyCard/GoalBuddyCard.tsx
+++ b/src/components/GoalBuddyCard/GoalBuddyCard.tsx
@@ -27,7 +27,7 @@ const GoalBuddyCard: React.FC<GoalBuddyCardProps> = ({
       key={goalBuddy.userId}
       onClick={onClick}
       className={clsx(
-        'flex flex-col sm:flex-row min-h-32 max-w-80 mx-2 my-2 sm:my-4 pb-2 px-5 pt-3 sm:py-2 sm:px-3 bg-white cursor-pointer duration-150 border border-slate-950 border-r-2 border-b-2 rounded-md relative',
+        'flex flex-col sm:flex-row min-h-32 max-w-80 mx-2 my-2 sm:my-4 pb-2 px-5 pt-4 sm:pt-3 sm:px-3 bg-white cursor-pointer duration-150 border border-slate-950 border-r-2 border-b-2 rounded-md relative',
         !isSidebarOpen && 'hover:scale-105', // Disable hover when sidebar is open
       )}
     >
@@ -54,7 +54,7 @@ const GoalBuddyCard: React.FC<GoalBuddyCardProps> = ({
         )}
       </div>
       <CardHeader className="self-start p-0">
-        <Avatar className="w-16 h-16">
+        <Avatar className="w-[61px] h-[61px]">
           <AvatarImage src={goalBuddy.profilePhoto} />
           <AvatarFallback className="bg-[#D9D9D9]" />
         </Avatar>


### PR DESCRIPTION
Made small tweaks to align closer to figma for desktop and mobile versions of the small goal buddy cards. Certain alignments may not be 100% exact but maybe a few pixels off.

![image](https://github.com/user-attachments/assets/34c65973-5cb1-4d74-b9e1-fce8eaa318aa)
![image](https://github.com/user-attachments/assets/874499cb-7d1f-4cc1-b2df-05cd5e50432a)

![image](https://github.com/user-attachments/assets/fd3f7a5b-2948-4168-8873-aeb5a9e2ace8)
![image](https://github.com/user-attachments/assets/3c6cfe7e-c31c-49d5-a24e-bee1a7375918)
