### PR TITLE
P6 cl 217 consistent error styling availabilities kk

### DIFF
--- a/src/components/AvailabilityInput/AvailabilityInput.tsx
+++ b/src/components/AvailabilityInput/AvailabilityInput.tsx
@@ -52,10 +52,10 @@ const AvailabilityInput: React.FC<AvailabilityInputProps> = ({index, idName, tim
                         <Label className="text-slate-900 text-sm font-medium font-montserrat leading-3" htmlFor={`startTime_${idName}`}>
                             {`Start Time`}
                         </Label>
-                        <Input type="string" id={`startTime_${idName}`} placeholder='0:00' value={timePeriod.startTime} onChange={handleStartTimeChange} className={`w-[40%] h-[24px] pl-[7.57px] pr-[7.57px] py-[5.05px] bg-white rounded border border-slate-300 justify-start items-center inline-flex text-slate-900 text-sm font-normal font-montserrat leading-3 ${startError ? "border-[#f44336]": ""}`}/>
+                        <Input type="string" id={`startTime_${idName}`} placeholder='0:00' value={timePeriod.startTime} onChange={handleStartTimeChange} className={`w-[40%] h-[24px] pl-[7.57px] pr-[7.57px] py-[5.05px] bg-white rounded border border-slate-300 justify-start items-center inline-flex text-slate-900 text-sm font-normal font-montserrat leading-3 ${startError ? "border-[#b71c1c] mb-1": ""}`}/>
                     </div>
                     {startError && 
-                        <p className="text-[#f44336] text-sm font-semibold font-montserrat leading-tight">{startError}</p>
+                        <p className="text-[#b71c1c] text-xs font-medium font-montserrat leading-none">{`*${startError}`}</p>
                     }
                 </div>
                 <div className="w-full flex flex-col my-3">
@@ -63,10 +63,10 @@ const AvailabilityInput: React.FC<AvailabilityInputProps> = ({index, idName, tim
                         <Label className="text-slate-900 text-sm font-medium font-montserrat leading-3" htmlFor={`endTime_${idName}`}>
                             {`End Time`}
                         </Label>
-                        <Input type="string" id={`endTime_${idName}`} placeholder='0:00' value={timePeriod.endTime} onChange={handleEndTimeChange} className={`w-[40%] h-[24px] pl-[7.57px] pr-[7.57px] py-[5.05px] bg-white rounded border border-slate-300 justify-start items-center inline-flex text-slate-900 text-sm font-normal font-montserrat leading-3 ${endError ? "border-[#f44336]": ""}`}/>
+                        <Input type="string" id={`endTime_${idName}`} placeholder='0:00' value={timePeriod.endTime} onChange={handleEndTimeChange} className={`w-[40%] h-[24px] pl-[7.57px] pr-[7.57px] py-[5.05px] bg-white rounded border border-slate-300 justify-start items-center inline-flex text-slate-900 text-sm font-normal font-montserrat leading-3 ${endError ? "border-[#b71c1c] mb-1": ""}`}/>
                     </div>
                     {endError && 
-                        <p className="text-[#f44336] text-sm font-semibold font-montserrat leading-tight">{endError}</p>
+                        <p className="text-[#b71c1c] text-xs font-medium font-montserrat leading-none">{`*${endError}`}</p>
                     }
                 </div>
             </div>

--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -229,7 +229,11 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
                         {`Set my availability`}
                     </h2>
                     {backendError && 
-                        <p className="text-[#e53935] mb-2 bg-red-100 rounded pl-1">{backendError}</p>
+                        <div className="flex justify-center items-center w-full">
+                            <div className="w-fit h-[29.56px] px-[9.85px] py-[6.57px] bg-white rounded-[5px] border-l border-r-2 border-t border-b-2 border-[#28363f] inline-flex">
+                                <p className="text-[#b71c1c] text-xs font-medium font-montserrat leading-none text-center w-auto">{backendError}</p>
+                            </div> 
+                        </div>
                     }
                     <DaySelection setSelectedDay={showAvailability} isError={dayError} />
                     {selectedDay && (

--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -196,19 +196,26 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
         setBackendError("");
     }
 
-    function makeConfirmationMessage(){
-        let message: string =`You've set availability for ${selectedDay}s at `;
-        if(timePeriodInputs.length === 0){
-            return `You've set ${selectedDay}s as unavailable.`
+    function makeConfirmationMessage(justTimes: boolean){
+        if(timePeriodInputs.length == 0 && justTimes){
+            return "";
+        
+        }else if(timePeriodInputs.length == 0){
+            return `You've set ${selectedDay}s as unavailable.`;
+        
+        }else if(!justTimes){
+            return `You've set availability for ${selectedDay}s at `;
+        
         }else{
+            let message: string = "";
             timePeriodInputs.forEach(period =>{
-                message += `${period.startTime}-${period.endTime}, `;
+                message += `${period.startTime} - ${period.endTime} and `;
             });
-        }
-        message = message.substring(0, (message.length-2));
-        message += ".";
+            message = message.substring(0, (message.length-5));
+            message += ".";
 
-        return message
+            return message
+        }
     }
 
   return (
@@ -218,7 +225,8 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
                 <div className="bg-[#ECFDF2] w-full h-full flex flex-col items-center justify-center my-1">
                     <ConfirmationIcon />
                     <h3 className="text-[#00892d] text-xl font-medium font-montserrat leading-none py-4">{`Confirmed`}</h3>
-                    <p className="text-[#00892d] text-sm font-normal font-montserrat  leading-tight text-center">{makeConfirmationMessage()}</p>
+                    <p className="text-[#00892d] text-sm font-normal font-montserrat  leading-tight text-center">{makeConfirmationMessage(false)}</p>
+                    <p className="text-[#00892d] text-sm font-normal font-montserrat  leading-tight text-center">{makeConfirmationMessage(true)}</p>
                 </div>
                 <Button variant="colabSecondary" size="colabSecondary" className="h-8" onClick={resetComponent}>{`Edit`}</Button>
             </div>


### PR DESCRIPTION
The changes in the PR update minor styling and text changes to closer match the hifi examples.

-The style of the other errors match the styling of the overlap text and add a leading asterisk.
-The confirmation next is broken to two lines, uses 'and' instead of a comma, and adds spacing around the time period dashes.

[Jira Ticket](https://makeitmvp.atlassian.net/browse/P6CL-217?atlOrigin=eyJpIjoiMTM4ZGEyMTA0Mzk3NDY2OGE3YzY1NDU5MjEzOWRlYzEiLCJwIjoiaiJ9)

![image](https://github.com/user-attachments/assets/3f84c729-a792-404a-bbe8-3f21d09136b4)

![image](https://github.com/user-attachments/assets/5dcfd6dd-2f97-4448-a909-624c35e3b1f1)
