### PR TITLE
P6 cl 211 heights of profile components in mobile kk

### DIFF
--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -219,7 +219,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
     }
 
   return (
-    <div className="w-full h-full flex flex-col justify-center pt-16 pb-8 px-8 flex-grow md:flex-grow-0">
+    <div className="w-full h-fit md:h-full flex flex-col justify-center pt-16 pb-8 px-8 flex-grow md:flex-grow-0 bg-blue">
         {confirmationState ? (
             <div className="bg-[#ECFDF2] w-full h-[75%] flex flex-col items-center justify-between p-4 rounded">
                 <div className="bg-[#ECFDF2] w-full h-full flex flex-col items-center justify-center my-1">
@@ -247,7 +247,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
                     {selectedDay && (
                         <div className="w-full h-full flex flex-col flex-grow md:flex-grow-0 justify-start">
                             <div className="w-full md:max-h-[372px] flex flex-col">
-                                <div className="sticky top-0 z-10">
+                                <div className="md:sticky md:top-0 md:z-10">
                                     <h3 className="mt-4 mb-1 text-[#0c0c0c] text-base font-semibold font-montserrat leading-[14.80px]">
                                         {`Time Zone: Eastern Standard Time`}
                                     </h3>

--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -265,7 +265,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
                                     ))}
                                 </div>
                             </div>
-                            <Button variant="colabAdd" size="colabAdd" className="my-1"onClick={addTimeRow}>
+                            <Button variant="colabAdd" size="colabAdd" className="my-1" onClick={addTimeRow}>
                                 <AddIcon />
                                 {`Add`}
                             </Button>

--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -219,9 +219,9 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
     }
 
   return (
-    <div className="w-full h-fit md:h-full flex flex-col justify-center pt-16 pb-8 px-8 flex-grow md:flex-grow-0 bg-blue">
+    <div className="w-full min-h-[46vh] h-fit md:h-full flex flex-col justify-center pt-16 pb-8 px-8 flex-grow md:flex-grow-0 bg-blue">
         {confirmationState ? (
-            <div className="bg-[#ECFDF2] w-full h-[75%] flex flex-col items-center justify-between p-4 rounded">
+            <div className="bg-[#ECFDF2] w-full h-[33vh] md:h-[75%] flex flex-col items-center justify-between p-4 rounded">
                 <div className="bg-[#ECFDF2] w-full h-full flex flex-col items-center justify-center my-1">
                     <ConfirmationIcon />
                     <h3 className="text-[#00892d] text-xl font-medium font-montserrat leading-none py-4">{`Confirmed`}</h3>

--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -232,7 +232,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
             </div>
         ) : (
             <div className="w-full h-full flex flex-col flex-grow md:flex-grow-0 items-center justify-between">
-                <div className="w-full h-[90%] flex flex-col flex-grow md:flex-grow-0 items-center">
+                <div className="w-full md:h-[90%] flex flex-col flex-grow md:flex-grow-0 items-center">
                     <h2 className="text-slate-950 text-2xl font-semibold font-fraunces leading-tight">
                         {`Set my availability`}
                     </h2>
@@ -272,7 +272,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
                         </div>
                     )}
                 </div>
-                <Button variant="colabPrimary" size="colabPrimary" disabled={!selectedDay} className="h-[38px]"  onClick={updateGoalBuddyAvailability}>
+                <Button variant="colabPrimary" size="colabPrimary" disabled={!selectedDay} className={`h-[38px] ${selectedDay ? "mt-2" : "mt-10 md:mt-2"}`}  onClick={updateGoalBuddyAvailability}>
                 {selectedDay ? "Confirm" : "Edit"}
                 </Button>
             </div>

--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -219,7 +219,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
     }
 
   return (
-    <div className="w-full min-h-[46vh] h-fit md:h-full flex flex-col justify-center pt-16 pb-8 px-8 flex-grow md:flex-grow-0 bg-blue">
+    <div className="w-full min-h-[46vh] md:min-h-0 h-fit md:h-full flex flex-col justify-center pt-16 pb-8 px-8 flex-grow md:flex-grow-0 bg-blue">
         {confirmationState ? (
             <div className="bg-[#ECFDF2] w-full h-[33vh] md:h-[75%] flex flex-col items-center justify-between p-4 rounded">
                 <div className="bg-[#ECFDF2] w-full h-full flex flex-col items-center justify-center my-1">
@@ -245,24 +245,24 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
                     }
                     <DaySelection setSelectedDay={showAvailability} isError={dayError} />
                     {selectedDay && (
-                        <div className="w-full h-full flex flex-col flex-grow md:flex-grow-0 justify-start">
-                            <div className="w-full md:max-h-[372px] flex flex-col">
-                                <div className="md:sticky md:top-0 md:z-10">
-                                    <h3 className="mt-4 mb-1 text-[#0c0c0c] text-base font-semibold font-montserrat leading-[14.80px]">
-                                        {`Time Zone: Eastern Standard Time`}
-                                    </h3>
-                                </div>
-                                {overlapError && 
-                                    <div className="flex justify-center items-center w-full">
-                                        <div className="w-fit h-[29.56px] px-[9.85px] py-[6.57px] bg-white rounded-[5px] border-l border-r-2 border-t border-b-2 border-[#28363f] inline-flex">
-                                            <p className="text-[#b71c1c] text-xs font-medium font-montserrat leading-none text-center w-auto">{overlapError}</p>
-                                        </div> 
+                        <div className="w-full md:max-h-[80%] flex flex-col">
+                            <h3 className="mt-4 mb-1 text-[#0c0c0c] text-base font-semibold font-montserrat leading-[14.80px]">
+                                {`Time Zone: Eastern Standard Time`}
+                            </h3>
+                            <div className="w-full h-full flex flex-col flex-grow md:flex-grow-0 md:overflow-y-auto justify-start">
+                                <div className="w-full flex flex-col">
+                                    {overlapError && 
+                                        <div className="flex justify-center items-center w-full">
+                                            <div className="w-fit h-[29.56px] px-[9.85px] py-[6.57px] bg-white rounded-[5px] border-l border-r-2 border-t border-b-2 border-[#28363f] inline-flex">
+                                                <p className="text-[#b71c1c] text-xs font-medium font-montserrat leading-none text-center w-auto">{overlapError}</p>
+                                            </div> 
+                                        </div>
+                                    }
+                                    <div className="overflow-auto h-full ">
+                                        {timePeriodInputs.map((period, index) => (
+                                        <AvailabilityInput key={index} index={index} idName={`${selectedDay}_${index}`} timePeriod={period} setTimePeriod={updateTimePeriod} deleteTimePeriod={deleteTimePeriod} errors={timeErrors} />
+                                        ))}
                                     </div>
-                                }
-                                <div className="overflow-auto h-full ">
-                                    {timePeriodInputs.map((period, index) => (
-                                    <AvailabilityInput key={index} index={index} idName={`${selectedDay}_${index}`} timePeriod={period} setTimePeriod={updateTimePeriod} deleteTimePeriod={deleteTimePeriod} errors={timeErrors} />
-                                    ))}
                                 </div>
                             </div>
                             <Button variant="colabAdd" size="colabAdd" className="my-1" onClick={addTimeRow}>

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardDescription } from '../ui/card'
+import { Card, CardContent } from '../ui/card'
 import { cn } from '../lib/utils'
 import MentorBadge from './MentorBadge'
 import GoalBuddyBadge from './GoalBuddyBadge'

--- a/src/components/Modal/UserProfileModal.tsx
+++ b/src/components/Modal/UserProfileModal.tsx
@@ -26,12 +26,12 @@ const UserprofileModal: React.FC<ModalProps> = ({
   return (
     <Dialog open={modalOpen} onOpenChange={setModalOpen} modal={true}>
   
-      <section className="flex w-[97vw] md:w-auto min-w-[60vw] h-[80vh] md:h-[75%] bg-white flex-col md:flex-row p-0 gap-0 border border-black rounded absolute md:right-[19px] top-[164px] md:top-[79px] mx-2 md:mx-0 z-50 overflow-auto md:overflow-hidden scrollbar-hidden"
+      <section className="flex flex-col md:flex-row w-[97vw] md:w-auto min-w-[60vw] h-[80vh] md:h-[75%] bg-white  p-0 gap-0 border border-black rounded absolute md:right-[19px] top-[164px] md:top-[79px] mx-2 md:mx-0 z-50 overflow-y-auto md:overflow-hidden scrollbar-hidden"
       
     aria-describedby={undefined}>
 
         <DialogTitle></DialogTitle>
-        <div className="flex flex-col w-full md:w-[57%] h-fit md:h-full pt-0 pl-0 overflow-hidden scrollbar-hidden bg-white rounded-tl rounded-bl">
+        <div className="flex flex-col w-full md:w-[57%] min-h-[100%] h-full flex-grow md:flex-grow-0 pt-0 pl-0 md:overflow-hidden scrollbar-hidden bg-white rounded-tl rounded-bl">
           <div
             className="absolute z-50 left-[5px] top-[5px] cursor-pointer"
             onClick={handleModalClick}
@@ -40,7 +40,7 @@ const UserprofileModal: React.FC<ModalProps> = ({
           </div>
           <UserProfile />
         </div>
-        <div className="flex flex-col items-center h-auto w-full md:w-[43%] bg-blue mt-1 md:m-0 p-0 flex-grow md:flex-grow-0 md:overflow-hidden md:rounded-tr md:rounded-br">
+        <div className="flex flex-col items-center h-full w-full md:w-[43%] bg-blue mt-1 md:m-0 p-0 flex-grow md:flex-grow-0 md:overflow-hidden md:rounded-tr md:rounded-br">
             {goalBuddyData ? (
               <AvailabilitySection activeGoalBuddy={goalBuddyData} updateGoalBuddy={updateGoalBuddyData} />
             ) : (

--- a/src/components/Modal/UserProfileModal.tsx
+++ b/src/components/Modal/UserProfileModal.tsx
@@ -1,10 +1,8 @@
-
 import { Dialog } from '@/components/ui/dialog'
 import { UserProfile } from '../UserProfile/UserProfile'
 import { DialogTitle } from '../ui/dialog'
 import AvailabilitySection from '../AvailabilitySection/AvailabilitySection'
 import { GoalBuddy } from '../../types/types'
-
 
 interface ModalProps {
   setModalOpen: React.Dispatch<React.SetStateAction<boolean>>
@@ -33,7 +31,7 @@ const UserprofileModal: React.FC<ModalProps> = ({
     aria-describedby={undefined}>
 
         <DialogTitle></DialogTitle>
-        <div className="flex flex-col w-full md:w-[57%] h-auto md:h-full pt-0 pl-0 overflow-y-auto scrollbar-hidden bg-white rounded-tl rounded-bl">
+        <div className="flex flex-col w-full md:w-[57%] h-fit md:h-full pt-0 pl-0 overflow-hidden scrollbar-hidden bg-white rounded-tl rounded-bl">
           <div
             className="absolute z-50 left-[5px] top-[5px] cursor-pointer"
             onClick={handleModalClick}

--- a/src/components/Modal/UserProfileModal.tsx
+++ b/src/components/Modal/UserProfileModal.tsx
@@ -40,7 +40,7 @@ const UserprofileModal: React.FC<ModalProps> = ({
           </div>
           <UserProfile />
         </div>
-        <div className="flex flex-col items-center h-full w-full md:w-[43%] bg-blue mt-1 md:m-0 p-0 flex-grow md:flex-grow-0 md:overflow-hidden md:rounded-tr md:rounded-br">
+        <div className="flex flex-col items-center h-fit md:h-full w-full md:w-[43%] bg-blue mt-1 md:m-0 p-0 flex-grow md:flex-grow-0 md:overflow-hidden md:rounded-tr md:rounded-br">
             {goalBuddyData ? (
               <AvailabilitySection activeGoalBuddy={goalBuddyData} updateGoalBuddy={updateGoalBuddyData} />
             ) : (

--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -143,9 +143,9 @@ export const UserProfile = () => {
   }
 
   return (
-    <div className="h-full w-full flex flex-col flex-grow overflow-hidden text-[14px] relative">
-      <div className="h-[12%] bg-yellow sticky top-0 left-0 w-[100%] z-10">
-        <Avatar className="lg:w-[90px] lg:h-[90px] md:w-[90px] md:h-[90px] w-[50px] h-[50px] lg:absolute md:absolute absolute right-[10%] top-[50%] ">
+    <div className="h-full w-full flex flex-col flex-grow text-[14px] relative">
+      <div className="h-[7%] md:h-[12%] bg-yellow md:sticky top-0 left-0 w-[100%] z-10">
+        <Avatar className="lg:w-[90px] lg:h-[90px] md:w-[90px] md:h-[90px] w-[62px] h-[62px] lg:absolute md:absolute absolute right-[10%] top-[4%] md:top-[50%] ">
           <AvatarFallback className="bg-[#B7D9B9]" />
           <AvatarImage
             src={userData ? userData.profilePhoto : ''}
@@ -153,7 +153,7 @@ export const UserProfile = () => {
           />
         </Avatar>
       </div>
-      <div className="h-[88%] flex flex-col overflow-visible">
+      <div className="h-[93%] md:h-[88%] flex flex-col">
         <div className="h-fit mt-2 flex flex-col pl-3 gap-0 font-medium text-sm font-montserrat tracking-wide">
           <label>
             First Name:{` `}
@@ -191,7 +191,7 @@ export const UserProfile = () => {
             ))}
           </label>
         </div>
-        <form className="flex-grow mt-2 pl-3 font-montserrat flex flex-col justify-between">
+        <form className="h-full md:h-auto flex-grow mt-2 pl-3 font-montserrat flex flex-col justify-between">
           <div className="flex flex-col flex-grow">
             <section className="border border-1 w-[95%]  border-gray-600 border-r-2 border-b-2 rounded relative shadow-lg py-2 px-3">
               <h2 className="text-base font-semibold font-fraunces tracking-regular leading-20">
@@ -232,7 +232,7 @@ export const UserProfile = () => {
               <textarea
                 value={editData.bio ? editData.bio : ''}
                 onChange={(e) => handleChange(e)}
-                className="w-full resize-none flex-grow max-h-full overflow-y-auto text-gray-600 min-h-[70%] p-2 text-[16px] shadow-lg bg-white font-[Montserrat] font-light rounded-sm border border-[#80909a]"
+                className="w-full resize-none flex-grow max-h-full overflow-y-auto text-gray-600 min-h-[70%] p-2 text-[16px] shadow-lg bg-white font-montserrat font-light rounded-sm border border-[#80909a]"
                 disabled={
                   editData.isEditing == false || editData.buttonText === 'Saved'
                 }

--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -145,7 +145,7 @@ export const UserProfile = () => {
   return (
     <div className="h-full w-full flex flex-col flex-grow text-[14px] relative">
       <div className="h-[7%] md:h-[12%] bg-yellow md:sticky top-0 left-0 w-[100%] z-10">
-        <Avatar className="lg:w-[90px] lg:h-[90px] md:w-[90px] md:h-[90px] w-[62px] h-[62px] lg:absolute md:absolute absolute right-[10%] top-[4%] md:top-[50%] ">
+        <Avatar className="lg:w-[90px] lg:h-[90px] md:w-[90px] md:h-[90px] w-[62px] h-[62px] lg:absolute md:absolute absolute right-[10%] top-[3%] md:top-[50%] ">
           <AvatarFallback className="bg-[#B7D9B9]" />
           <AvatarImage
             src={userData ? userData.profilePhoto : ''}

--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -7,6 +7,7 @@ import mentor from '../../assets/icons/graduation-cap.svg'
 import networking from '../../assets/icons/network.svg'
 import goalbuddy from '../../assets/icons/smile-plus.svg'
 import React from 'react'
+import { Button } from '../ui/button'
 interface EditData {
   selectedInterests: string[]
   bio: string
@@ -142,7 +143,7 @@ export const UserProfile = () => {
   }
 
   return (
-    <div className="h-[100%] w-[100%] text-[14px] relative">
+    <div className="h-full w-full flex flex-col flex-grow overflow-hidden text-[14px] relative">
       <div className="h-[12%] bg-yellow sticky top-0 left-0 w-[100%] z-10">
         <Avatar className="lg:w-[90px] lg:h-[90px] md:w-[90px] md:h-[90px] w-[50px] h-[50px] lg:absolute md:absolute absolute right-[10%] top-[50%] ">
           <AvatarFallback className="bg-[#B7D9B9]" />
@@ -152,8 +153,8 @@ export const UserProfile = () => {
           />
         </Avatar>
       </div>
-      <div className="h-[88%]">
-        <div className="mt-2 flex flex-col pl-3 gap-0 font-medium text-sm font-montserrat tracking-wide">
+      <div className="h-[88%] flex flex-col overflow-visible">
+        <div className="h-fit mt-2 flex flex-col pl-3 gap-0 font-medium text-sm font-montserrat tracking-wide">
           <label>
             First Name:{` `}
             <span className="font-normal">{userData?.firstName}</span>
@@ -190,62 +191,64 @@ export const UserProfile = () => {
             ))}
           </label>
         </div>
-        <form className="h-[90%] mt-2 pl-3 font-montserrat">
-          <section className="border border-1 w-[95%]  border-gray-600 border-r-2 border-b-2 rounded p-1 relative shadow-lg pl-2">
-            <h2 className="text-base font-semibold font-fraunces tracking-regular leading-20">
-              Co-Lab Role{' '}
-            </h2>
-            {interestsLabel.map((interest, _index) => {
-              return (
-                <div key={_index} className="flex gap-5">
-                  <div className="flex gap-2 w-[40%]">
-                    <div className="w-[20px] h-[20px]">
-                      <img src={icons[_index]} />
+        <form className="flex-grow mt-2 pl-3 font-montserrat flex flex-col justify-between">
+          <div className="flex flex-col flex-grow">
+            <section className="border border-1 w-[95%]  border-gray-600 border-r-2 border-b-2 rounded relative shadow-lg py-2 px-3">
+              <h2 className="text-base font-semibold font-fraunces tracking-regular leading-20">
+                Co-Lab Role{' '}
+              </h2>
+              {interestsLabel.map((interest, _index) => {
+                return (
+                  <div key={_index} className="flex gap-5">
+                    <div className="flex gap-2 w-[40%]">
+                      <div className="w-[20px] h-[20px]">
+                        <img src={icons[_index]} />
+                      </div>
+                      <span className="tracking-wide text-sm font-medium font-montserrat">
+                        {interest}
+                      </span>
                     </div>
-                    <span className="tracking-wide text-sm font-medium font-montserrat">
-                      {interest}
-                    </span>
-                  </div>
 
-                  <div className="flex items-center justify-center">
-                    <input
-                      type="checkbox"
-                      checked={editData.selectedInterests.includes(interest)}
-                      onChange={() => handleChange(interest)}
-                      disabled={editData.isEditing === false}
-                      className="appearance-none w-4 h-4 border border-gray-600 rounded checked:bg-black"
-                    />
+                    <div className="flex items-center justify-center">
+                      <input
+                        type="checkbox"
+                        checked={editData.selectedInterests.includes(interest)}
+                        onChange={() => handleChange(interest)}
+                        disabled={editData.isEditing === false}
+                        className="appearance-none w-4 h-4 border border-gray-600 rounded checked:bg-black"
+                      />
+                    </div>
                   </div>
-                </div>
-              )
-            })}
-            {errInterest && (
-              <p className="text-sm font-semibold font-montserrat m-0 text-red-600 absolute top-1 right-2">
-                *Please select your role
-              </p>
-            )}
-          </section>
-          <section className=" border border-gray-600 border-r-2 border-b-2 shadow-md rounded h-[30%] w-[95%] mt-3 pl-3 pt-1">
-            <h2 className="p-0 font-fraunces font-semibold text-base">About</h2>
-            <textarea
-              value={editData.bio ? editData.bio : ''}
-              onChange={(e) => handleChange(e)}
-              className="resize-none text-gray-600 w-[95%] h-[70%] p-2 text-[16px] border border-gray-300 shadow-lg bg-white font-[Montserrat] font-light"
-              disabled={
-                editData.isEditing == false || editData.buttonText === 'Saved'
-              }
-            />
-          </section>
-
-          <article className="flex w-[95%] justify-end">
-            <button
-              className={`bg-blue px-[15px] py-[4px] mt-[7px] rounded-xl text-xl font-semibold border border-gray-600 text-white tracking-wide font-montserrat ${editData.buttonText === 'Not Saved' ? 'bg-red-600' : ''}`}
+                )
+              })}
+              {errInterest && (
+                <p className="text-sm font-semibold font-montserrat m-0 text-red-600 absolute top-1 right-2">
+                  *Please select your role
+                </p>
+              )}
+            </section>
+            <section className="flex flex-col flex-grow border border-gray-600 border-r-2 border-b-2 shadow-md rounded min-h-[30%] w-[95%] mt-2 px-[12.9px] py-[19.2px]">
+              <h2 className="p-0 font-fraunces font-semibold text-base">{`My Profile`}</h2>
+              <textarea
+                value={editData.bio ? editData.bio : ''}
+                onChange={(e) => handleChange(e)}
+                className="w-full resize-none flex-grow max-h-full overflow-y-auto text-gray-600 min-h-[70%] p-2 text-[16px] shadow-lg bg-white font-[Montserrat] font-light rounded-sm border border-[#80909a]"
+                disabled={
+                  editData.isEditing == false || editData.buttonText === 'Saved'
+                }
+              />
+            </section>
+          </div>
+          <article className="flex w-[95%] justify-end pb-8 mt-5">
+            <Button
+              variant="colabSecondary"
+              size="colabSecondary"
               type="button"
+              className={`h-[38px] ${editData.buttonText === 'Not Saved' ? 'bg-red-600' : ''}`}
               onClick={handleInterestAndBioClick}
-              style={{ backgroundColor: '#0264D4' }}
             >
               {editData.buttonText}
-            </button>
+            </Button>
           </article>
         </form>
       </div>


### PR DESCRIPTION
This PR addresses [Jira Ticket 211](https://makeitmvp.atlassian.net/browse/P6CL-211?atlOrigin=eyJpIjoiOThhNmViZDkxZjAzNGRlOGEwZWRjYWY0ODRkNDVmZjIiLCJwIjoiaiJ9) where the two components in the user profile were not showing their full heights and were swallowing each when arranged vertically in mobile.

To test this ticket, you should view in desktop first to ensure no changes have occurred in this view. Then proceed to the mobile view and make sure that you can scroll to view both components and nothing overlaps, exceeds, or is cut off.

PLEASE NOTE THIS IS ONLY DEALING WITH THE HEIGHT/OVERLAP BUG. NOT OTHER MOBILE STYLING.