### PR TITLE
P6 cl 221 style availabilities component for mobile kk

### DIFF
--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -219,7 +219,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
     }
 
   return (
-    <div className="w-full min-h-[46vh] md:min-h-0 h-fit md:h-full flex flex-col justify-center pt-4 md:pt-16 pb-10 md:pb-8 px-[56px] md:px-8 flex-grow md:flex-grow-0 overflow-hidden bg-blue">
+    <div className="w-full min-h-[48vh] md:min-h-0 h-fit md:h-full flex flex-col justify-center pt-4 md:pt-16 pb-10 md:pb-8 px-[56px] md:px-8 flex-grow md:flex-grow-0 overflow-hidden bg-blue">
         {confirmationState ? (
             <div className="w-full h-full flex flex-col items-center justify-center min-h-[480px] md:min-h-0">
                 <div className="bg-[#ECFDF2] w-full min-h-[348px] md:min-h-0 md:h-[75%] flex flex-col items-center justify-between p-4 rounded">

--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -219,16 +219,18 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
     }
 
   return (
-    <div className="w-full min-h-[46vh] md:min-h-0 h-fit md:h-full flex flex-col justify-center pt-16 pb-8 px-8 flex-grow md:flex-grow-0 bg-blue">
+    <div className="w-full min-h-[46vh] md:min-h-0 h-fit md:h-full flex flex-col justify-center pt-4 md:pt-16 pb-10 md:pb-8 px-[56px] md:px-8 flex-grow md:flex-grow-0 overflow-hidden bg-blue">
         {confirmationState ? (
-            <div className="bg-[#ECFDF2] w-full h-[33vh] md:h-[75%] flex flex-col items-center justify-between p-4 rounded">
-                <div className="bg-[#ECFDF2] w-full h-full flex flex-col items-center justify-center my-1">
-                    <ConfirmationIcon />
-                    <h3 className="text-[#00892d] text-xl font-medium font-montserrat leading-none py-4">{`Confirmed`}</h3>
-                    <p className="text-[#00892d] text-sm font-normal font-montserrat  leading-tight text-center">{makeConfirmationMessage(false)}</p>
-                    <p className="text-[#00892d] text-sm font-normal font-montserrat  leading-tight text-center">{makeConfirmationMessage(true)}</p>
+            <div className="w-full h-full flex flex-col items-center justify-center min-h-[480px] md:min-h-0">
+                <div className="bg-[#ECFDF2] w-full min-h-[348px] md:min-h-0 md:h-[75%] flex flex-col items-center justify-between p-4 rounded">
+                    <div className="bg-[#ECFDF2] w-full h-full flex flex-col items-center justify-center my-1">
+                        <ConfirmationIcon />
+                        <h3 className="text-[#00892d] text-xl font-medium font-montserrat leading-none py-4">{`Confirmed`}</h3>
+                        <p className="text-[#00892d] text-sm font-normal font-montserrat  leading-tight text-center">{makeConfirmationMessage(false)}</p>
+                        <p className="text-[#00892d] text-sm font-normal font-montserrat  leading-tight text-center">{makeConfirmationMessage(true)}</p>
+                    </div>
+                    <Button variant="colabSecondary" size="colabSecondary" className="h-8 mb-4 md:mb-0" onClick={resetComponent}>{`Edit`}</Button>
                 </div>
-                <Button variant="colabSecondary" size="colabSecondary" className="h-8" onClick={resetComponent}>{`Edit`}</Button>
             </div>
         ) : (
             <div className="w-full h-full flex flex-col flex-grow md:flex-grow-0 items-center justify-between">
@@ -272,7 +274,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
                         </div>
                     )}
                 </div>
-                <Button variant="colabPrimary" size="colabPrimary" disabled={!selectedDay} className={`h-[38px] ${selectedDay ? "mt-2" : "mt-10 md:mt-2"}`}  onClick={updateGoalBuddyAvailability}>
+                <Button variant="colabPrimary" size="colabPrimary" disabled={!selectedDay} className={`h-[38px] ${selectedDay ? "mt-12 md:mt-2" : "mt-10 md:mt-2"}`}  onClick={updateGoalBuddyAvailability}>
                 {selectedDay ? "Confirm" : "Edit"}
                 </Button>
             </div>

--- a/src/components/DaySelection/DaySelection.tsx
+++ b/src/components/DaySelection/DaySelection.tsx
@@ -28,7 +28,7 @@ const DaySelection: React.FC<DaySelectionProps> = ({
   ]
 
     return (
-        <div className="w-full mt-4 flex flex-col justify-center items-center">
+        <div className="w-full mt-3 md:mt-4 flex flex-col justify-center items-center">
             <Select onValueChange={(value: DayOfWeek) => setSelectedDay(value)}>
                 <SelectTrigger className={`h-[49.68px] px-[16.26px] py-[10.84px] bg-white rounded-lg border-l border-r-2 border-t border-b-2 border-[#28363f] justify-between items-center inline-flex" ${isError ? "border-[#b71c1c]": ""}`}>
                     <SelectValue placeholder="Select a day" />

--- a/src/components/Modal/UserProfileModal.tsx
+++ b/src/components/Modal/UserProfileModal.tsx
@@ -26,7 +26,7 @@ const UserprofileModal: React.FC<ModalProps> = ({
   return (
     <Dialog open={modalOpen} onOpenChange={setModalOpen} modal={true}>
   
-      <section className="flex flex-col md:flex-row w-[97vw] md:w-auto min-w-[60vw] h-[80vh] md:h-[75%] bg-white p-0 gap-0 border border-black rounded absolute md:right-[19px] top-[164px] md:top-[79px] mx-2 md:mx-0 z-50 overflow-y-auto md:overflow-hidden scrollbar-hidden"
+      <section className="flex flex-col md:flex-row w-[97vw] md:w-auto min-w-[60vw] h-[80vh] md:h-[75vh] bg-white p-0 gap-0 border border-black rounded absolute md:right-[19px] top-[164px] md:top-[79px] mx-2 md:mx-0 z-50 overflow-y-auto md:overflow-hidden scrollbar-hidden"
       
     aria-describedby={undefined}>
 

--- a/src/components/Modal/UserProfileModal.tsx
+++ b/src/components/Modal/UserProfileModal.tsx
@@ -26,7 +26,7 @@ const UserprofileModal: React.FC<ModalProps> = ({
   return (
     <Dialog open={modalOpen} onOpenChange={setModalOpen} modal={true}>
   
-      <section className="flex flex-col md:flex-row w-[97vw] md:w-auto min-w-[60vw] h-[80vh] md:h-[75%] bg-white  p-0 gap-0 border border-black rounded absolute md:right-[19px] top-[164px] md:top-[79px] mx-2 md:mx-0 z-50 overflow-y-auto md:overflow-hidden scrollbar-hidden"
+      <section className="flex flex-col md:flex-row w-[97vw] md:w-auto min-w-[60vw] h-[80vh] md:h-[75%] bg-white p-0 gap-0 border border-black rounded absolute md:right-[19px] top-[164px] md:top-[79px] mx-2 md:mx-0 z-50 overflow-y-auto md:overflow-hidden scrollbar-hidden"
       
     aria-describedby={undefined}>
 


### PR DESCRIPTION
This PR adjusts the padding of elements in the Availabilities component for when it is in mobile view to better match the prototype. It also fixes a display bug that was causing the profile modal to grow when the day dropdown was opened.

To test, look at the component in desktop view to be sure that none of the changes have affected this area's styling. Then open it in mobile view to see and compare that resemble the prototype. 

[Jira Ticket](https://makeitmvp.atlassian.net/browse/P6CL-221?atlOrigin=eyJpIjoiZmExNWY2MTUzYWY1NGFkNTliMjgxYTBmZTVhNmY1NzUiLCJwIjoiaiJ9)