### PR TITLE
P6 cl 236 adjust meeting component mobile kk

### DIFF
--- a/src/components/BookingCalendar/BookingCalendar.tsx
+++ b/src/components/BookingCalendar/BookingCalendar.tsx
@@ -14,7 +14,7 @@ const BookingCalendar: React.FC<BookingCalendarProps> = ({ selectedDate, setDate
         mode="single"
         selected={selectedDate}
         onSelect={setDate}
-        className="rounded-md border bg-white font-montserrat text-[#28363f] text-sm font-medium leading-tight"
+        className="rounded-md border bg-white font-montserrat text-[#28363f] text-sm font-medium leading-tight w-full"
       />
     </div>
   );

--- a/src/components/GoalBuddyProfile/GoalBuddyProfile.tsx
+++ b/src/components/GoalBuddyProfile/GoalBuddyProfile.tsx
@@ -51,7 +51,7 @@ const GoalBuddyProfile: React.FC<GoalBuddyProfileProps> = ({ goalBuddy }) => {
           }
         </div>
       </div>
-      <div className="h-[90%] md:h-[88%]">
+      <div className="h-[90%] md:h-[88%] md:overflow-y-auto scrollbar-hidden">
         <div className="mt-2 flex flex-col pl-3 gap-1 font-semibold font-font-montserrat ">
           <label>
             First Name:{' '}
@@ -108,7 +108,7 @@ const GoalBuddyProfile: React.FC<GoalBuddyProfileProps> = ({ goalBuddy }) => {
             })}
           </section>
         </div>
-        <section className="border border-gray-600 border-r-2 border-b-2 rounded-md pl-4 pt-1 pb-1 ml-3 mt-4 mr-2 mb-3 md:mb-0 shadow-[1px_0px_2px_1px_rgba(0,0,0,0.2)]">
+        <section className="border border-gray-600 border-r-2 border-b-2 rounded-md pl-4 pt-1 pb-1 ml-3 mt-4 mr-2 mb-3 shadow-[1px_0px_2px_1px_rgba(0,0,0,0.2)]">
           <div className=" font-fraunces font-semibold text-lg tracking-wide">
             About
           </div>

--- a/src/components/GoalBuddyProfile/GoalBuddyProfile.tsx
+++ b/src/components/GoalBuddyProfile/GoalBuddyProfile.tsx
@@ -34,15 +34,15 @@ const GoalBuddyProfile: React.FC<GoalBuddyProfileProps> = ({ goalBuddy }) => {
   ]
   return (
     <div className="h-[100%] bg-white text-[16px] rounded-l-sm">
-      <div className="h-[20%] lg:h-[12%] md:h-[12%] bg-yellow relative md:relative sm:relative rounded-tl-md">
-        <Avatar className="w-[55px] h-[55px] lg:w-[90px] lg:h-[90px] md:w-[70px] md:h-[70px] absolute lg:absolute md:absolute right-[5%] top-[65%]  lg:right-[10%] lg:top-[40%] ">
+      <div className="h-[45px] lg:h-[12%] md:h-[12%] bg-yellow relative md:relative sm:relative rounded-tl-md">
+        <Avatar className="w-[55px] h-[55px] lg:w-[90px] lg:h-[90px] md:w-[70px] md:h-[70px] absolute lg:absolute md:absolute top-[50%] right-[5%] md:top-[65%]  lg:right-[10%] lg:top-[40%] ">
           <AvatarFallback className="bg-[#B7D9B9]" />
           <AvatarImage
             src={goalBuddy ? goalBuddy.profilePhoto : ''}
             alt="@shadcn"
           />
         </Avatar>
-        <p className='lg:hidden md:hidden absolute top-[70%] right-[23%] font-fraunces text-md font-bold'>Co-Lab Role</p>
+        <p className='lg:hidden md:hidden absolute top-[50%] right-[21%] font-fraunces text-md font-bold'>Co-Lab Role</p>
         <div className='flex gap-1 absolute lg:hidden md:hidden top-[110%] right-[20%]'>
           {
             goalBuddy && colabRoles.map((colabRole, index) => (

--- a/src/components/GoalBuddyProfile/GoalBuddyProfile.tsx
+++ b/src/components/GoalBuddyProfile/GoalBuddyProfile.tsx
@@ -33,8 +33,8 @@ const GoalBuddyProfile: React.FC<GoalBuddyProfileProps> = ({ goalBuddy }) => {
     { key: 'isNetworking', label: 'Networking', icon: Network },
   ]
   return (
-    <div className="h-[100%] bg-white text-[16px] rounded-l-sm">
-      <div className="h-[45px] lg:h-[12%] md:h-[12%] bg-yellow relative md:relative sm:relative rounded-tl-md">
+    <div className="h-full flex flex-col bg-white text-[16px] rounded-l-sm">
+      <div className="h-[10%] lg:h-[12%] md:h-[12%] bg-yellow relative md:relative sm:relative rounded-tl-md">
         <Avatar className="w-[55px] h-[55px] lg:w-[90px] lg:h-[90px] md:w-[70px] md:h-[70px] absolute lg:absolute md:absolute top-[50%] right-[5%] md:top-[65%]  lg:right-[10%] lg:top-[40%] ">
           <AvatarFallback className="bg-[#B7D9B9]" />
           <AvatarImage
@@ -51,7 +51,7 @@ const GoalBuddyProfile: React.FC<GoalBuddyProfileProps> = ({ goalBuddy }) => {
           }
         </div>
       </div>
-      <div className="h-[88%]">
+      <div className="h-[90%] md:h-[88%]">
         <div className="mt-2 flex flex-col pl-3 gap-1 font-semibold font-font-montserrat ">
           <label>
             First Name:{' '}
@@ -108,11 +108,11 @@ const GoalBuddyProfile: React.FC<GoalBuddyProfileProps> = ({ goalBuddy }) => {
             })}
           </section>
         </div>
-        <section className="border border-gray-600 border-r-2 border-b-2 rounded-md pl-4 pt-1 pb-1 ml-3 mt-4 mr-2 shadow-[1px_0px_2px_1px_rgba(0,0,0,0.2)]">
+        <section className="border border-gray-600 border-r-2 border-b-2 rounded-md pl-4 pt-1 pb-1 ml-3 mt-4 mr-2 mb-3 md:mb-0 shadow-[1px_0px_2px_1px_rgba(0,0,0,0.2)]">
           <div className=" font-fraunces font-semibold text-lg tracking-wide">
             About
           </div>
-          <p className=" font-[Montserrat] text-gray-400 tracking-wider">
+          <p className="font-montserrat text-gray-400 tracking-wider">
             {goalBuddy?.bio}
           </p>
         </section>

--- a/src/components/MeetingSetupSection/MeetingSetupSection.tsx
+++ b/src/components/MeetingSetupSection/MeetingSetupSection.tsx
@@ -214,7 +214,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
   
 
   return (
-    <div className="flex flex-col w-full h-fit md:h-full flex-grow md:flex-grow-0">
+    <div className="flex flex-col w-full h-fit md:h-full flex-grow md:flex-grow-0 bg-blue">
       {confirmationState ? (
         <div className="flex flex-col items-center justify-between pt-7 pb-4 px-12 md:px-8 md:py-4 h-[472px] md:h-full w-full">
           <div className="flex flex-col items-center justify-start md:justify-center h-full w-full">
@@ -237,7 +237,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
             onClick={resetState}
             variant="colabPrimary"
             size="colabPrimary"
-            className={`mb-2 md:mb-0 tracking-wide lg:min-w-[195px]`}
+            className={`mb-2 md:mb-0 tracking-wide md:whitespace-normal md:min-h-12 md:h-fit md:py-1 lg:min-w-[195px]`}
           >
             {`Book Another Session`}
           </Button>
@@ -251,7 +251,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
             </div>
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-between py-4 px-12 md:p-3 h-full w-full flex-grow md:flex-grow-0">
+          <div className="flex flex-col items-center justify-between py-4 px-12 md:py-3 md:px-8 h-full w-full flex-grow md:flex-grow-0">
             <div className="flex flex-col items-center justify-start flex-grow max-h-[90%] w-full">
               <h2 className="font-semibold font-fraunces tracking-wide text-center text-2xl mb-1">{`Book a Meeting`}</h2>
               {date ? (
@@ -262,7 +262,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
               )}
               <BookingCalendar selectedDate={date} setDate={populateTimeListings} />
               {date &&
-                <div className="flex flex-col items-center justify-start flex-grow w-full px-3 my-6 md:my-0">
+                <div className="flex flex-col items-center justify-start flex-grow w-full px-3 md:px-0 my-6 md:my-3">
                   <h3 className="text-[#0c0c0c] text-sm text-center font-semibold font-montserrat leading-[14.80px] my-1">{`Time Zone: Eastern Standard Time`}</h3>
 
                   <TimeSelectionList
@@ -278,7 +278,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
               disabled={date === undefined || selectedTime === undefined}
               variant="colabPrimary"
               size="colabPrimary"
-              className="my-10 md:my-0"
+              className="my-10 md:my-2"
             >
               {`Confirm`}
             </Button>

--- a/src/components/MeetingSetupSection/MeetingSetupSection.tsx
+++ b/src/components/MeetingSetupSection/MeetingSetupSection.tsx
@@ -214,7 +214,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
   
 
   return (
-    <div className="flex flex-col w-full h-full">
+    <div className="flex flex-col w-full h-fit md:h-full flex-grow md:flex-grow-0">
       {confirmationState ? (
         <div className="flex flex-col items-center justify-between py-4 px-8 h-full w-full">
           <div className="flex flex-col items-center justify-center h-full w-full">
@@ -243,7 +243,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
           </Button>
         </div>
       ) : (
-        <div className="flex flex-col items-center justify-center h-full w-full">
+        <div className="flex flex-col items-center justify-center h-full w-full flex-grow md:flex-grow-0">
         {backendError ? (
           <div className="flex flex-col items-center justify-center h-full w-full">
             <div className="w-full h-[60%] flex flex-col items-center justify-center bg-red-100 rounded">
@@ -251,8 +251,8 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
             </div>
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-between p-3 h-full w-full">
-            <div className="flex flex-col items-center justify-start flex-grow max-h-[90%] w-full overflow-auto scrollbar-hide">
+          <div className="flex flex-col items-center justify-between p-3 h-full w-full flex-grow md:flex-grow-0">
+            <div className="flex flex-col items-center justify-start flex-grow max-h-[90%] w-full">
               <h2 className="font-semibold font-fraunces tracking-wide text-center text-2xl mb-1">{`Book a Meeting`}</h2>
               {date ? (
                 <h3 className="font-medium font-monserrat text-sm mb-1">{date.toDateString()}</h3>

--- a/src/components/MeetingSetupSection/MeetingSetupSection.tsx
+++ b/src/components/MeetingSetupSection/MeetingSetupSection.tsx
@@ -216,9 +216,9 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
   return (
     <div className="flex flex-col w-full h-fit md:h-full flex-grow md:flex-grow-0">
       {confirmationState ? (
-        <div className="flex flex-col items-center justify-between py-4 px-8 h-full w-full">
-          <div className="flex flex-col items-center justify-center h-full w-full">
-            <div className="bg-[#ECFDF2] w-full h-[66%] flex flex-col items-center justify-between p-4 rounded">
+        <div className="flex flex-col items-center justify-between pt-7 pb-4 px-12 md:px-8 md:py-4 h-[472px] md:h-full w-full">
+          <div className="flex flex-col items-center justify-start md:justify-center h-full w-full">
+            <div className="bg-[#ECFDF2] w-full h-[340px] md:h-[66%] flex flex-col items-center justify-between p-4 rounded">
                 <div className="bg-[#ECFDF2] w-full h-full flex flex-col items-center justify-center my-1">
                     <ConfirmationIcon />
                     <h3 className="text-[#00892d] text-base font-medium font-montserrat leading-none py-4 text-center my-2">
@@ -237,7 +237,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
             onClick={resetState}
             variant="colabPrimary"
             size="colabPrimary"
-            className={`tracking-wide min-w-[195px]`}
+            className={`mb-2 md:mb-0 tracking-wide lg:min-w-[195px]`}
           >
             {`Book Another Session`}
           </Button>
@@ -251,17 +251,18 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
             </div>
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-between p-3 h-full w-full flex-grow md:flex-grow-0">
+          <div className="flex flex-col items-center justify-between py-4 px-12 md:p-3 h-full w-full flex-grow md:flex-grow-0">
             <div className="flex flex-col items-center justify-start flex-grow max-h-[90%] w-full">
               <h2 className="font-semibold font-fraunces tracking-wide text-center text-2xl mb-1">{`Book a Meeting`}</h2>
               {date ? (
-                <h3 className="font-medium font-monserrat text-sm mb-1">{date.toDateString()}</h3>
+                <h3 className="font-medium font-montserrat text-base md:text-sm mb-1">{date.toDateString()}</h3>
               ) : (
-                <h3 className="font-medium font-monserrat text-sm mb-1">{`Select a date`}</h3>
+                <h3 className="font-medium font-montserrat text-base md:text-sm mb-1">{`Select a date`}</h3>
+                // Monday, 7th Nov 2023
               )}
               <BookingCalendar selectedDate={date} setDate={populateTimeListings} />
               {date &&
-                <div className="flex flex-col items-center justify-start flex-grow w-full px-3">
+                <div className="flex flex-col items-center justify-start flex-grow w-full px-3 my-6 md:my-0">
                   <h3 className="text-[#0c0c0c] text-sm text-center font-semibold font-montserrat leading-[14.80px] my-1">{`Time Zone: Eastern Standard Time`}</h3>
 
                   <TimeSelectionList
@@ -277,6 +278,7 @@ const MeetingSetupSection: React.FC<MeetingSetupSectionProps> = ({
               disabled={date === undefined || selectedTime === undefined}
               variant="colabPrimary"
               size="colabPrimary"
+              className="my-10 md:my-0"
             >
               {`Confirm`}
             </Button>

--- a/src/components/Modal/GoalBuddyProfileModal.tsx
+++ b/src/components/Modal/GoalBuddyProfileModal.tsx
@@ -28,14 +28,14 @@ const GoalBuddyProfileModal: React.FC<ModalProps> = ({
   return (
     <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
       <DialogContent
-        className="flex flex-col md:flex-row lg:flex-row max-w-[90vw] md:max-w-[70vw] lg:max-w-[50vw] h-[90vh] md:h-[70vh] lg:h-[70vh] p-0 gap-0 border border-black overflow-y-auto md:overflow-hidden scrollbar-hidden"
+        className="flex flex-col md:flex-row lg:flex-row max-w-[90vw] md:max-w-[70vw] lg:max-w-[50vw] h-[90vh] md:h-[70vh] lg:h-[70vh] p-0 gap-0 border border-black rounded overflow-y-auto md:overflow-hidden scrollbar-hidden"
         aria-describedby={undefined}
       >
      < DialogTitle></DialogTitle>
-        <div className="min-h-[50%] h-full w-full md:w-[55%] lg:w-[55%] pt-0 flex-grow md:flex-grow-0 md:overflow-y-auto scrollbar-hidden">
+        <div className="min-h-[50%] h-full w-full md:w-[55%] lg:w-[55%] pt-0 flex flex-col flex-grow md:flex-grow-0 md:overflow-y-auto scrollbar-hidden">
           <GoalBuddyProfile goalBuddy={goalBuddy} />
         </div>
-        <div className="flex flex-col h-full items-center w-full md:w-[45%] lg:w-[45%] bg-blue p-0 md:overflow-y-auto scrollbar-hidden flex-grow md:flex-grow-0">
+        <div className="flex flex-col h-full items-center w-full md:w-[45%] lg:w-[45%] bg-blue p-0 md:overflow-y-auto scrollbar-hidden flex-grow md:flex-grow-0 mt-3 md:mt-0">
           {userContext && userData ? (
             <MeetingSetupSection activeUserId={userData.id} showingUser={goalBuddy} />
           ) : (

--- a/src/components/Modal/GoalBuddyProfileModal.tsx
+++ b/src/components/Modal/GoalBuddyProfileModal.tsx
@@ -28,14 +28,14 @@ const GoalBuddyProfileModal: React.FC<ModalProps> = ({
   return (
     <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
       <DialogContent
-        className="flex flex-col max-w-[90vw] h-[90%] lg:max-w-[50vw] md:max-w-[70vw] lg:h-[70%] md:h-[70%]  lg:flex-row md:flex-row  p-0 gap-0 border border-black "
+        className="flex flex-col md:flex-row lg:flex-row max-w-[90vw] md:max-w-[70vw] lg:max-w-[50vw] h-[90vh] md:h-[70vh] lg:h-[70vh] p-0 gap-0 border border-black overflow-y-auto md:overflow-hidden scrollbar-hidden"
         aria-describedby={undefined}
       >
      < DialogTitle></DialogTitle>
-        <div className="h-[60%] lg:w-[55%] md:w-[55%] lg:h-[100%] md:h-[100%] pt-0 overflow-y-auto scrollbar-hidden">
+        <div className="min-h-[50%] h-full w-full md:w-[55%] lg:w-[55%] pt-0 flex-grow md:flex-grow-0 md:overflow-y-auto scrollbar-hidden">
           <GoalBuddyProfile goalBuddy={goalBuddy} />
         </div>
-        <div className="flex flex-col h-[40%] items-center w-[100%] lg:w-[45%] md:w-[45%]  md:h-[100%] bg-[#279af1] p-0 overflow-y-auto scrollbar-hidden ">
+        <div className="flex flex-col h-full items-center w-full md:w-[45%] lg:w-[45%] bg-blue p-0 md:overflow-y-auto scrollbar-hidden flex-grow md:flex-grow-0">
           {userContext && userData ? (
             <MeetingSetupSection activeUserId={userData.id} showingUser={goalBuddy} />
           ) : (

--- a/src/components/Modal/GoalBuddyProfileModal.tsx
+++ b/src/components/Modal/GoalBuddyProfileModal.tsx
@@ -32,7 +32,7 @@ const GoalBuddyProfileModal: React.FC<ModalProps> = ({
         aria-describedby={undefined}
       >
      < DialogTitle></DialogTitle>
-        <div className="min-h-[50%] h-full w-full md:w-[55%] lg:w-[55%] pt-0 flex flex-col flex-grow md:flex-grow-0 md:overflow-y-auto scrollbar-hidden">
+        <div className="min-h-[50%] h-full w-full md:w-[55%] lg:w-[55%] pt-0 flex flex-col flex-grow md:flex-grow-0">
           <GoalBuddyProfile goalBuddy={goalBuddy} />
         </div>
         <div className="flex flex-col h-full items-center w-full md:w-[45%] lg:w-[45%] bg-blue p-0 md:overflow-y-auto scrollbar-hidden flex-grow md:flex-grow-0 mt-3 md:mt-0">


### PR DESCRIPTION
The PR is in regards to [Jira Ticket 236](https://makeitmvp.atlassian.net/browse/P6CL-236?atlOrigin=eyJpIjoiNjEyMGIzMTcyZjFhNDRjYzk4N2NiNjJiNmM2YWY0ZGMiLCJwIjoiaiJ9) - styling meeting component for mobile.
While completing this ticket I also addressed [Jira Ticket 219](https://makeitmvp.atlassian.net/browse/P6CL-219?atlOrigin=eyJpIjoiZTdhZjBjZDQwMDZlNDE1ZmFlYjE0NDcwYWQwYmZiMjQiLCJwIjoiaiJ9) where the left side content was being cutoff and inaccessible by scrolling.

I also addressed some resizing issues brought up previously, but may not have had tickets (ie. in meeting confirmation state, the book another session button is cutoff if the screen is still desktop but very small width.

To Test This PR
Please try going through the states of the meeting modal in various sizes. When in "regular" states the styling should try to match the  hi-fis and in irregular states, should be a responsive version of that styling without cutoffs or accessible with scrolling.