### PR TITLE
238-Adjust-Minimum-Availabilities-Height

### DIFF
--- a/src/components/AvailabilitySection/AvailabilitySection.tsx
+++ b/src/components/AvailabilitySection/AvailabilitySection.tsx
@@ -233,7 +233,7 @@ const AvailabilitySection: React.FC<AvailabilitySectionProps> = ({ activeGoalBud
                 </div>
             </div>
         ) : (
-            <div className="w-full h-full flex flex-col flex-grow md:flex-grow-0 items-center justify-between">
+            <div className="w-full h-full min-h-[464px] flex flex-col flex-grow md:flex-grow-0 items-center justify-between">
                 <div className="w-full md:h-[90%] flex flex-col flex-grow md:flex-grow-0 items-center">
                     <h2 className="text-slate-950 text-2xl font-semibold font-fraunces leading-tight">
                         {`Set my availability`}


### PR DESCRIPTION
Set a minimum height for the div holding the day select and edit/confirm button to force a height that the dropdown in an open state does not overlap the button.

This was to address styling reported [here](https://makeitmvp.slack.com/files/U07RZ07CPCN/F08F9058LLF/screen_recording_2025-03-01_at_1.34.20___pm.mov).

[Jira Ticket](https://makeitmvp.atlassian.net/browse/P6CL-238?atlOrigin=eyJpIjoiODNjOGY0ZWZiMTExNDU1MDljOWIxNDE5ODE3N2U4ZDMiLCJwIjoiaiJ9)

To test, open the user profile (more concerned with mobile but test desktop too) and see that the dropdown does not cover the confirm/edit button.